### PR TITLE
🚧 WIP: added Rollup Analyzer for bundle analysis

### DIFF
--- a/lib/bundle/bundler.js
+++ b/lib/bundle/bundler.js
@@ -1,4 +1,7 @@
 let rollup = require("rollup");
+let rollupAnalyzer = require("rollup-analyzer");
+
+let report = msg => void console.error(msg);
 
 module.exports = function generateBundle(entryPoint, target, config, cache) {
 	let { readConfig, writeConfig } = config;
@@ -6,7 +9,16 @@ module.exports = function generateBundle(entryPoint, target, config, cache) {
 		input: entryPoint,
 		cache
 	});
+	let analyzer = rollupAnalyzer({ // TODO: configurable
+		//root // TODO: pass through `configDir`
+		limit: 5
+	});
 	return rollup.rollup(options).
+		then(bundle => {
+			return analyzer.formatted(bundle).
+				then(report, report).
+				then(_ => bundle);
+		}).
 		then(bundle => {
 			let modules = bundle.modules.reduce(collectModulePaths, new Set());
 			return bundle.generate(writeConfig).

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ module.exports = (config, assetManager, { watcher, browsers, compact } = {}) => 
 	watcher.on("edit", filepaths => {
 		bundles.forEach(bundle => {
 			let res = bundle.recompile(...filepaths);
-			res && // guards against irrelevant changes
+			res && // disregard irrelevant changes
 				res.then(makeWriter(bundle, assetManager));
 		});
 	});

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"faucet-pipeline": "~1.0.0-rc.3",
 		"rollup": "^0.56.5",
 		"rollup-plugin-cleanup": "^2.0.0",
-		"rollup-plugin-commonjs": "^9.0.0",
+		"rollup-plugin-commonjs": "^9.1.0",
 		"rollup-plugin-node-resolve": "^3.2.0"
 	},
 	"devDependencies": {
@@ -38,8 +38,9 @@
 		"faucet-pipeline-jsx": "file:pkg/faucet-pipeline-jsx",
 		"faucet-pipeline-typescript": "file:pkg/faucet-pipeline-typescript",
 		"json-diff": "^0.5.2",
-		"mocha": "^5.0.3",
+		"mocha": "^5.0.4",
 		"npm-run-all": "^4.1.2",
-		"release-util-fnd": "^1.1.0"
+		"release-util-fnd": "^1.1.0",
+		"rollup-analyzer": "^1.1.0"
 	}
 }


### PR DESCRIPTION
see commit message for details; suggestions welcome

`npm test` provides a basic impression of what it looks like

caveat: It looks like tree shaking is not being taken into account, which makes results questionable.
```
test_browserslist
transpiling JavaScript for IE 11
…
-----------------------------
bundle size: 13.464 KB
-----------------------------
file: babelHelpers
size: 13.145 KB
percent: 97.63%
dependents: 1
  - /src/util.js
-----------------------------
file: /src/util.js
size: 213 Bytes
percent: 1.58%
dependents: 1
  - /src/index.js
-----------------------------
file: /src/index.js
size: 106 Bytes
percent: 0.79%
dependents: 0
-----------------------------
```
(The bundle's actual size is just 0,5 kB.)