### PR TITLE
bundle: Remove obsolete workaround

### DIFF
--- a/lib/bundle/config.js
+++ b/lib/bundle/config.js
@@ -78,7 +78,7 @@ function generateConfig({ extensions = [], externals, format, moduleName,
 	]);
 	if(compact) {
 		let cleanup = require("rollup-plugin-cleanup");
-		plugins = plugins.concat(cleanup({ maxEmptyLines: -1 }));
+		plugins = plugins.concat(cleanup());
 	}
 
 	let cfg = { format, plugins };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 	"dependencies": {
 		"faucet-pipeline": "~1.0.0-rc.5",
 		"rollup": "^0.57.1",
-		"rollup-plugin-cleanup": "^2.0.0",
+		"rollup-plugin-cleanup": "^2.0.1",
 		"rollup-plugin-commonjs": "^9.1.0",
 		"rollup-plugin-node-resolve": "^3.3.0"
 	},

--- a/test/unit/test_bundling.js
+++ b/test/unit/test_bundling.js
@@ -327,7 +327,6 @@ console.log(\`[…] $\{util}\`); // eslint-disable-line no-console
 let txt = \`foo
 
 bar\`;
-
 console.log(\`[…] $\{txt}\`);
 					`.trim())
 				}]);


### PR DESCRIPTION
rollup-plugin-cleanup v2.0.1 includes a fix
for the bug that we worked around in 7d064b1.

This change declares that we require the version with that fix,
removes the configuration working around the bug,
and adapts the tests so they expect the plugin to actually run.