### PR TITLE
added template for pull requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+[impact](https://semver.org):
+
+* [ ] patch (backwards-compatible tweaks)
+* [ ] minor (new functionality, but backwards-compatible)
+* [ ] major (incompatible API changes)
+
+<!-- -->
+
+* [ ] affects end users
+  ⇒ update website documentation
+* [ ] affects developers
+
+☝️  always update `CHANGELOG.md`


### PR DESCRIPTION
> unusually, this mostly serves as a reminder for maintainers for now

This is all I could come up with for now. It's not particularly well-phrased and I've seen repos where PR templates were used more effectively (e.g. [Rollup](https://github.com/rollup/rollup/tree/master/.github), [Babel](https://github.com/babel/babel/blob/master/.github/PULL_REQUEST_TEMPLATE.md)), but I can't remember any details right now and wouldn't want to go full bureaucrat anyway.