### PR TITLE
Bugfix: Return a Promise when writing files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,7 +52,7 @@ function makeWriter(bundle, assetManager) {
 		if(bundle.fingerprint !== undefined) {
 			options.fingerprint = bundle.fingerprint;
 		}
-		assetManager.writeFile(bundle.target, code, options);
+		return assetManager.writeFile(bundle.target, code, options);
 	};
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "faucet-pipeline-js",
-	"version": "2.0.6",
+	"version": "2.0.7",
 	"description": "JavaScript module bundling for faucet-pipeline",
 	"author": "FND",
 	"contributors": [


### PR DESCRIPTION
This leads to unwanted behavior, as files in the build step "scripts" are not entirely done, but "markup" steps already start working. It is then possible that JS files are missing in the manifest when a markup pipeline is trying to read them.