### PR TITLE
Add experimental support for symlinked modules

### DIFF
--- a/lib/bundle/config.js
+++ b/lib/bundle/config.js
@@ -88,8 +88,13 @@ function generateConfig({ externals, format, exports, // eslint-disable-next-lin
 
 	plugins = plugins.concat([
 		nodeResolve({ extensions }),
-		commonjs({ include: "node_modules/**" })
+		commonjs({ include: /node_modules/ })
 	]);
+
+	if(process.env.FAUCET_EXPERIMENTAL_SYMLINKS === "true") {
+		cfg.preserveSymlinks = true;
+	}
+
 	if(compact) {
 		cfg.compact = true;
 		plugins = plugins.concat(determineCompacting(compact));
@@ -111,7 +116,7 @@ function generateConfig({ externals, format, exports, // eslint-disable-next-lin
 	}
 
 	// distinguish between (roughly) read and write settings
-	let read = ["external", "plugins"];
+	let read = ["external", "plugins", "preserveSymlinks"];
 	return Object.keys(cfg).reduce((memo, key) => {
 		let type = read.includes(key) ? "readConfig" : "writeConfig";
 		memo[type][key] = cfg[key];

--- a/test/unit/fixtures/external/cjs-module/index.js
+++ b/test/unit/fixtures/external/cjs-module/index.js
@@ -1,0 +1,3 @@
+exports.dummy = {
+	some: "dummy value"
+};

--- a/test/unit/fixtures/src/import-symlinked.js
+++ b/test/unit/fixtures/src/import-symlinked.js
@@ -1,0 +1,3 @@
+import { dummy } from "some-cjs-module";
+
+console.log(dummy); // eslint-disable-line no-console


### PR DESCRIPTION
When linking external dependencies using `npm_link`, rollups commonjs plugin does not process files in the symlinked directory correctly. To support this, rollup need the `preserveSymlinks` setting to be true.

Since we cannot assess at the moment whether this setting will break some other build, we put it behind an experimental flag. So you need to set the environment varialbe `FAUCET_EXPERIMENTAL_SYMLINKS` to `"true"` to enable preserving symlinks.