### PR TITLE
v3.1

### DIFF
--- a/lib/bundle/config.js
+++ b/lib/bundle/config.js
@@ -55,6 +55,7 @@ function generateConfig({ externals, format, exports, // eslint-disable-next-lin
 	if(esnext || jsx) {
 		let transpiler = Object.assign({}, esnext, jsx);
 		if(esnext) {
+			console.error("WARNING: \"esnext\" is deprecated");
 			transpiler.esnext = true;
 		}
 		if(jsx) {
@@ -96,6 +97,10 @@ function generateConfig({ externals, format, exports, // eslint-disable-next-lin
 	}
 	cfg.plugins = plugins;
 
+	if(format) {
+		console.error("WARNING: \"format\" is deprecated.\n" +
+			"faucet-pipeline-js will always compile to ESM in the future.");
+	}
 	cfg.format = determineModuleFormat(format);
 	if(exports) {
 		if(NAMELESS_MODULES.has(format)) {
@@ -147,6 +152,7 @@ function determineCompacting(type = true) {
 		var options = { compress: false, mangle: false }; // eslint-disable-line no-var
 		break;
 	case "mangle":
+		console.error("WARNING: compact option \"mangle\" is deprecated, use \"minify\"");
 		options = { compress: false, mangle: true };
 		break;
 	default:

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 let Bundle = require("./bundle");
 let { abort, repr } = require("faucet-pipeline-core/lib/util");
 let path = require("path");
+let browserslist = require("browserslist");
 
 module.exports = {
 	key: "js",
@@ -10,7 +11,12 @@ module.exports = {
 	plugin: faucetJS
 };
 
-function faucetJS(config, assetManager, { browsers, compact, sourcemaps } = {}) {
+function faucetJS(config, assetManager, { compact, sourcemaps } = {}) {
+	let browsers = browserslist.findConfig(assetManager.referenceDir) || {};
+	if(browsers.substr) {
+		browsers = [browsers];
+	}
+
 	let bundlers = config.map(bundleConfig => makeBundler(bundleConfig,
 			assetManager, { browsers, compact, sourcemaps }));
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 	"dependencies": {
 		"@rollup/plugin-commonjs": "~29.0.1",
 		"@rollup/plugin-node-resolve": "~16.0.3",
+		"browserslist": "^4.28.1",
 		"faucet-pipeline-core": "^2.0.0",
 		"rollup": "^4.59.0",
 		"rollup-plugin-cleanup": "~3.2.1"


### PR DESCRIPTION
Proposal for changes in v3.1:
* Inline determining the browserslist as we plan to drop it from core
* Add deprecation warnings for things we want to drop in the next major version:
    * esnext: The days of ES5 are long gone, and nowadays Babel does transformations we would not recommend. So let's drop it.
    * format: Why would you compile to anything but ESM? Let's drop it. It is the default right now, and I would be surprised if any project that is still alive would change it to something else.
    * mangling the source code: There is no reason to shorten variable names because compression exists. Reducing whitespace is a non-destructive option (modern browsers even have "format JS" as an option in the devtools), and makes a difference in file size even with compression, so we keep it.