### PR TITLE
3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@ faucet-pipeline-js version history
 ==================================
 
 
+v3.1.0
+------
+
+_TBD_
+
+
 v3.0.2
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@ faucet-pipeline-js version history
 ==================================
 
 
+v3.1.0
+------
+
+_TBD_
+
+notable changes for end users:
+
+*   deprecated `esnext`, `jsx`, `exports` and `format` options as well as
+    `compact: mangle` setting
+
+    This functionality will be removed in v4 due to lack of user needs:
+    `esnext`, `format` and `exports` should no longer be necessary, now that ESM
+    is well-established. JSX conversion typically requires framework-specific
+    tooling these days, which goes beyond faucet-pipeline's stated objectives.
+    `mangle` was deemed excessive and ultimately unhelpful; `minify` should be
+    used instead.
+
+*   reduced number of dependencies
+
+no significant changes for developers
+
+
 v3.0.2
 ------
 

--- a/lib/bundle/babel.js
+++ b/lib/bundle/babel.js
@@ -2,7 +2,8 @@
 
 let { loadExtension } = require("faucet-pipeline-core/lib/util");
 
-module.exports = function generateTranspiler({ esnext, jsx, exclude }, { browsers }) {
+module.exports = async function generateTranspiler({ esnext, jsx, exclude },
+		{ browsers }) { // eslint-disable-line indent
 	let settings = {
 		babelHelpers: "bundled"
 	};
@@ -40,7 +41,7 @@ module.exports = function generateTranspiler({ esnext, jsx, exclude }, { browser
 		settings.plugins = plugins;
 	}
 
-	let babel = loadExtension("@rollup/plugin-babel",
+	let babel = await loadExtension("@rollup/plugin-babel",
 			"failed to activate ESNext transpiler", "faucet-pipeline-esnext");
 	return babel.default(settings);
 };

--- a/lib/bundle/config.js
+++ b/lib/bundle/config.js
@@ -55,9 +55,11 @@ function generateConfig({ externals, format, exports, // eslint-disable-next-lin
 	if(esnext || jsx) {
 		let transpiler = Object.assign({}, esnext, jsx);
 		if(esnext) {
+			console.error("WARNING: `esnext` option is deprecated");
 			transpiler.esnext = true;
 		}
 		if(jsx) {
+			console.error("WARNING: `jsx` option is deprecated");
 			extensions.push(".jsx");
 			// just to be safe, discard JSX-specifics on parent object
 			delete transpiler.pragma;
@@ -96,8 +98,13 @@ function generateConfig({ externals, format, exports, // eslint-disable-next-lin
 	}
 	cfg.plugins = plugins;
 
+	if(format) {
+		console.error("WARNING: `format` option is deprecated; " +
+				"faucet-pipeline-js will always compile to ESM in the future");
+	}
 	cfg.format = determineModuleFormat(format);
 	if(exports) {
+		console.error("WARNING: `exports` option is deprecated");
 		if(NAMELESS_MODULES.has(format)) {
 			console.error(`WARNING: ${repr(format, false)} bundles ignore ` +
 					`${repr("exports", false)} configuration`);
@@ -147,6 +154,8 @@ function determineCompacting(type = true) {
 		var options = { compress: false, mangle: false }; // eslint-disable-line no-var
 		break;
 	case "mangle":
+		console.error("WARNING: `compact` option `mangle` is deprecated; " +
+				"use `minify` instead");
 		options = { compress: false, mangle: true };
 		break;
 	default:

--- a/lib/bundle/config.js
+++ b/lib/bundle/config.js
@@ -16,7 +16,7 @@ let MODULE_FORMATS = { // maps faucet identifiers to Rollup identifiers
 	cjs: false, // deprecated in favor of `commonjs`
 	iife: true
 };
-let NAMELESS_MODULES = new Set(["es", "amd", "cjs"]); // NB: Rollup identifiers
+let NAMELESS_MODULES = new Set(["esm", "amd", "cjs"]); // NB: Rollup identifiers
 
 module.exports = generateConfig;
 

--- a/lib/bundle/config.js
+++ b/lib/bundle/config.js
@@ -45,9 +45,9 @@ module.exports = generateConfig;
 // * `sourcemaps`, if truthy, activates inline source-map generation
 // * `compact`, if truthy, compresses the bundle's code - see `determineCompacting`
 //    for compression levels, determined by the respective value
-function generateConfig({ externals, format, exports, // eslint-disable-next-line indent
-		esnext, jsx, typescript, // eslint-disable-next-line indent
-		sourcemaps, compact }, { browsers }) {
+async function generateConfig({ externals, format,
+		exports, esnext, jsx, typescript, // eslint-disable-line indent
+		sourcemaps, compact }, { browsers }) { // eslint-disable-line indent
 	let cfg = { sourcemap: sourcemaps };
 	let plugins = [];
 	let extensions = [".js"];
@@ -77,11 +77,11 @@ function generateConfig({ externals, format, exports, // eslint-disable-next-lin
 			console.error("transpiling JavaScript for", browsers.join(", "));
 		}
 
-		let plugin = generateTranspiler(transpiler, { browsers });
+		let plugin = await generateTranspiler(transpiler, { browsers });
 		plugins.push(plugin);
 	}
 	if(typescript) {
-		let ts = loadExtension("@rollup/plugin-typescript",
+		let ts = await loadExtension("@rollup/plugin-typescript",
 				"failed to activate TypeScript", "faucet-pipeline-typescript");
 		extensions.push(".ts");
 		// TODO: provide defaults and abstractions for low-level options?
@@ -94,7 +94,7 @@ function generateConfig({ externals, format, exports, // eslint-disable-next-lin
 	]);
 	if(compact) {
 		cfg.compact = true;
-		plugins = plugins.concat(determineCompacting(compact));
+		plugins = plugins.concat(await determineCompacting(compact));
 	}
 	cfg.plugins = plugins;
 
@@ -145,7 +145,7 @@ function determineModuleFormat(format = "esm") {
 	}
 }
 
-function determineCompacting(type = true) {
+async function determineCompacting(type = true) {
 	switch(type) {
 	case true: // default
 	case "compact":
@@ -162,7 +162,7 @@ function determineCompacting(type = true) {
 		abort(`unknown compacting option ${type}`);
 	}
 
-	let terser = loadExtension("@rollup/plugin-terser",
+	let terser = await loadExtension("@rollup/plugin-terser",
 			"failed to activate minification", "faucet-pipeline-jsmin");
 	return terser(options);
 }

--- a/lib/bundle/config.js
+++ b/lib/bundle/config.js
@@ -55,9 +55,11 @@ function generateConfig({ externals, format, exports, // eslint-disable-next-lin
 	if(esnext || jsx) {
 		let transpiler = Object.assign({}, esnext, jsx);
 		if(esnext) {
+			console.error("WARNING: `esnext` option is deprecated");
 			transpiler.esnext = true;
 		}
 		if(jsx) {
+			console.error("WARNING: `jsx` option is deprecated");
 			extensions.push(".jsx");
 			// just to be safe, discard JSX-specifics on parent object
 			delete transpiler.pragma;
@@ -96,8 +98,13 @@ function generateConfig({ externals, format, exports, // eslint-disable-next-lin
 	}
 	cfg.plugins = plugins;
 
+	if(format) {
+		console.error("WARNING: `format` option is deprecated.\n" +
+			"faucet-pipeline-js will always compile to ESM in the future.");
+	}
 	cfg.format = determineModuleFormat(format);
 	if(exports) {
+		console.error("WARNING: `exports` option is deprecated.");
 		if(NAMELESS_MODULES.has(format)) {
 			console.error(`WARNING: ${repr(format, false)} bundles ignore ` +
 					`${repr("exports", false)} configuration`);
@@ -147,6 +154,7 @@ function determineCompacting(type = true) {
 		var options = { compress: false, mangle: false }; // eslint-disable-line no-var
 		break;
 	case "mangle":
+		console.error("WARNING: compact option `mangle` is deprecated; use `minify` instead");
 		options = { compress: false, mangle: true };
 		break;
 	default:

--- a/lib/bundle/config.js
+++ b/lib/bundle/config.js
@@ -45,9 +45,9 @@ module.exports = generateConfig;
 // * `sourcemaps`, if truthy, activates inline source-map generation
 // * `compact`, if truthy, compresses the bundle's code - see `determineCompacting`
 //    for compression levels, determined by the respective value
-function generateConfig({ externals, format, exports, // eslint-disable-next-line indent
-		esnext, jsx, typescript, // eslint-disable-next-line indent
-		sourcemaps, compact }, { browsers }) {
+async function generateConfig({ externals, format,
+		exports, esnext, jsx, typescript, // eslint-disable-line indent
+		sourcemaps, compact }, { browsers }) { // eslint-disable-line indent
 	let cfg = { sourcemap: sourcemaps };
 	let plugins = [];
 	let extensions = [".js"];
@@ -77,11 +77,11 @@ function generateConfig({ externals, format, exports, // eslint-disable-next-lin
 			console.error("transpiling JavaScript for", browsers.join(", "));
 		}
 
-		let plugin = generateTranspiler(transpiler, { browsers });
+		let plugin = await generateTranspiler(transpiler, { browsers });
 		plugins.push(plugin);
 	}
 	if(typescript) {
-		let ts = loadExtension("@rollup/plugin-typescript",
+		let ts = await loadExtension("@rollup/plugin-typescript",
 				"failed to activate TypeScript", "faucet-pipeline-typescript");
 		extensions.push(".ts");
 		// TODO: provide defaults and abstractions for low-level options?
@@ -94,7 +94,7 @@ function generateConfig({ externals, format, exports, // eslint-disable-next-lin
 	]);
 	if(compact) {
 		cfg.compact = true;
-		plugins = plugins.concat(determineCompacting(compact));
+		plugins = plugins.concat(await determineCompacting(compact));
 	}
 	cfg.plugins = plugins;
 
@@ -145,7 +145,7 @@ function determineModuleFormat(format = "esm") {
 	}
 }
 
-function determineCompacting(type = true) {
+async function determineCompacting(type = true) {
 	switch(type) {
 	case true: // default
 	case "compact":
@@ -161,7 +161,7 @@ function determineCompacting(type = true) {
 		abort(`unknown compacting option ${type}`);
 	}
 
-	let terser = loadExtension("@rollup/plugin-terser",
+	let terser = await loadExtension("@rollup/plugin-terser",
 			"failed to activate minification", "faucet-pipeline-jsmin");
 	return terser(options);
 }

--- a/lib/bundle/index.js
+++ b/lib/bundle/index.js
@@ -33,7 +33,8 @@ module.exports = class Bundle {
 			return false;
 		}
 
-		return generateBundle(this.entryPoint, this._config, this._cache).
+		return this._config.
+			then(config => generateBundle(this.entryPoint, config, this._cache)).
 			then(({ code, modules, cache }) => {
 				this._modules = modules;
 				this._cache = cache;

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 let Bundle = require("./bundle");
 let { abort, repr } = require("faucet-pipeline-core/lib/util");
 let path = require("path");
+let browserslist = require("browserslist");
 
 module.exports = {
 	key: "js",
@@ -10,7 +11,12 @@ module.exports = {
 	plugin: faucetJS
 };
 
-function faucetJS(config, assetManager, { browsers, compact, sourcemaps } = {}) {
+function faucetJS(config, assetManager, { compact, sourcemaps } = {}) {
+	let browsers = browserslist.findConfig(assetManager.referenceDir) || {};
+	if(browsers.substr) {
+		browsers = [browsers];
+	}
+
 	let bundlers = config.map(bundleConfig => makeBundler(bundleConfig,
 			assetManager, { browsers, compact, sourcemaps }));
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 let Bundle = require("./bundle");
 let { abort, repr } = require("faucet-pipeline-core/lib/util");
+let browserslist = require("browserslist");
 let path = require("path");
 
 module.exports = {
@@ -10,7 +11,12 @@ module.exports = {
 	plugin: faucetJS
 };
 
-function faucetJS(config, assetManager, { browsers, compact, sourcemaps } = {}) {
+function faucetJS(config, assetManager, { compact, sourcemaps } = {}) {
+	let browsers = browserslist.findConfig(assetManager.referenceDir) || {};
+	if(browsers.substr) {
+		browsers = [browsers];
+	}
+
 	let bundlers = config.map(bundleConfig => makeBundler(bundleConfig,
 			assetManager, { browsers, compact, sourcemaps }));
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	},
 	"main": "lib/index.js",
 	"scripts": {
-		"test": "npm-run-all lint --parallel test:unit test:cli",
+		"test": "npm run lint && npm run test:unit && npm run test:cli",
 		"test:cli": "./test/cli/run",
 		"test:unit": "node --test ./test/unit/test_*.js",
 		"lint": "eslint --cache --ext .js --ext .jsx ./lib ./bin/validate-dependencies ./test/unit ./samples ./pkg && echo ✓"
@@ -37,7 +37,6 @@
 		"faucet-pipeline-jsx": "file:pkg/faucet-pipeline-jsx",
 		"faucet-pipeline-typescript": "file:pkg/faucet-pipeline-typescript",
 		"json-diff": "^1.0.6",
-		"npm-run-all": "^4.1.5",
 		"release-util-fnd": "^3.0.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 	"dependencies": {
 		"@rollup/plugin-commonjs": "~29.0.1",
 		"@rollup/plugin-node-resolve": "~16.0.3",
-		"faucet-pipeline-core": "^2.0.0",
+		"faucet-pipeline-core": "^2.0.0 || ^3.0.0",
 		"rollup": "^4.59.0",
 		"rollup-plugin-cleanup": "~3.2.1"
 	},

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
 	"scripts": {
 		"test": "npm-run-all lint --parallel test:unit test:cli",
 		"test:cli": "./test/cli/run",
-		"test:unit": "mocha test/unit/test_*.js",
-		"lint": "eslint --cache --ext .js --ext .jsx lib bin/validate-dependencies test/unit samples pkg && echo ✓"
+		"test:unit": "node --test ./test/unit/test_*.js",
+		"lint": "eslint --cache --ext .js --ext .jsx ./lib ./bin/validate-dependencies ./test/unit ./samples ./pkg && echo ✓"
 	},
 	"engines": {
 		"node": ">=22"
@@ -37,7 +37,6 @@
 		"faucet-pipeline-jsx": "file:pkg/faucet-pipeline-jsx",
 		"faucet-pipeline-typescript": "file:pkg/faucet-pipeline-typescript",
 		"json-diff": "^1.0.6",
-		"mocha": "^11.7.5",
 		"npm-run-all": "^4.1.5",
 		"release-util-fnd": "^3.0.0"
 	}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 	"dependencies": {
 		"@rollup/plugin-commonjs": "~29.0.1",
 		"@rollup/plugin-node-resolve": "~16.0.3",
+		"browserslist": "^4.28.1",
 		"faucet-pipeline-core": "^2.0.0 || ^3.0.0",
 		"rollup": "^4.59.0",
 		"rollup-plugin-cleanup": "~3.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "faucet-pipeline-js",
-	"version": "3.0.2",
+	"version": "3.1.0",
 	"description": "JavaScript module bundling for faucet-pipeline",
 	"author": "FND",
 	"contributors": ["Lucas Dohmen <lucas@dohmen.io>"],

--- a/pkg/faucet-pipeline-esnext/package.json
+++ b/pkg/faucet-pipeline-esnext/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "faucet-pipeline-esnext",
-	"version": "3.0.2",
+	"version": "3.1.0",
 	"description": "ES6 and beyond for faucet-pipeline",
 	"author": "FND",
 	"license": "Apache-2.0",

--- a/pkg/faucet-pipeline-jsmin/package.json
+++ b/pkg/faucet-pipeline-jsmin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "faucet-pipeline-jsmin",
-	"version": "3.0.2",
+	"version": "3.1.0",
 	"description": "JavaScript minification for faucet-pipeline",
 	"author": "FND",
 	"license": "Apache-2.0",

--- a/pkg/faucet-pipeline-jsx/package.json
+++ b/pkg/faucet-pipeline-jsx/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "faucet-pipeline-jsx",
-	"version": "3.0.2",
+	"version": "3.1.0",
 	"description": "JSX for faucet-pipeline",
 	"author": "FND",
 	"license": "Apache-2.0",

--- a/pkg/faucet-pipeline-typescript/package.json
+++ b/pkg/faucet-pipeline-typescript/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "faucet-pipeline-typescript",
-	"version": "3.0.2",
+	"version": "3.1.0",
 	"description": "TypeScript for faucet-pipeline",
 	"author": "FND",
 	"contributors": [

--- a/test/unit/test_bundling.js
+++ b/test/unit/test_bundling.js
@@ -1,10 +1,9 @@
-/* global describe, it, beforeEach, afterEach */
 "use strict";
-
 let { MockAssetManager, makeBundle, FIXTURES_DIR } = require("./util");
 let faucetJS = require("../../lib").plugin;
-let path = require("path");
-let assert = require("assert");
+let { describe, it, beforeEach, afterEach } = require("node:test");
+let path = require("node:path");
+let assert = require("node:assert");
 
 let DEFAULT_OPTIONS = {
 	browsers: {}

--- a/test/unit/test_bundling.js
+++ b/test/unit/test_bundling.js
@@ -226,28 +226,6 @@ console.log(\`[…] $\{MYLIB}\`); // eslint-disable-line no-console
 			});
 	});
 
-	it("should take into account Browserslist while transpiling", () => {
-		let config = [{
-			source: "./src/index.js",
-			target: "./dist/bundle.js",
-			esnext: true
-		}];
-		let assetManager = new MockAssetManager(FIXTURES_DIR);
-
-		let browsers = { defaults: ["Chrome 63"] };
-		return faucetJS(config, assetManager, { browsers })().
-			then(_ => {
-				assetManager.assertWrites([{
-					filepath: path.resolve(FIXTURES_DIR, "./dist/bundle.js"),
-					content: makeBundle(`
-var util = "UTIL";
-
-console.log(\`[…] $\{util}\`); // eslint-disable-line no-console
-					`)
-				}]);
-			});
-	});
-
 	it("should allow suppressing Browserslist auto-config while transpiling", () => {
 		let config = [{
 			source: "./src/index.js",
@@ -267,33 +245,6 @@ console.log(\`[…] $\{util}\`); // eslint-disable-line no-console
 var util = "UTIL";
 
 console.log("[\\u2026] ".concat(util)); // eslint-disable-line no-console
-					`)
-				}]);
-			});
-	});
-
-	it("should allow specifying an alternative Browserslist group", () => {
-		let config = [{
-			source: "./src/index.js",
-			target: "./dist/bundle.js",
-			esnext: {
-				browserslist: "modern"
-			}
-		}];
-		let assetManager = new MockAssetManager(FIXTURES_DIR);
-
-		let browsers = {
-			defaults: ["IE 11"],
-			modern: ["Chrome 63"]
-		};
-		return faucetJS(config, assetManager, { browsers })().
-			then(_ => {
-				assetManager.assertWrites([{
-					filepath: path.resolve(FIXTURES_DIR, "./dist/bundle.js"),
-					content: makeBundle(`
-var util = "UTIL";
-
-console.log(\`[…] $\{util}\`); // eslint-disable-line no-console
 					`)
 				}]);
 			});


### PR DESCRIPTION
Re-opened PR for #233 as a lot of the changes already got released separately. I also merged in my proposed deprecation warnings.

* Replaced Mocha with Node's built-in test runner
* Remove npm-run-all
* fixed nameless module designations (I can't remember anything about this)
* Add deprecation warnings for things we want to drop in the next major version:
    * esnext: The days of ES5 are long gone, and nowadays Babel does transformations we would not recommend. So let's drop it.
    * jsx: There is basically only one JSX-based framework left that you could use without vite: Preact. It therefore makes little sense to support JSX for our project.
    * format: Why would you compile to anything but ESM? Let's drop it. It is the default right now, and I would be surprised if any project that is still alive would change it to something else.
    * exports: As this is not possible in ESM, we drop that as well.
    * mangling the source code: There is no reason to shorten variable names because compression exists. Reducing whitespace is a non-destructive option (modern browsers even have "format JS" as an option in the devtools), and makes a difference in file size even with compression, so we keep it.
* updated internals for compatability with faucet v3
* Inline determining the browserslist as we plan to drop it from core

_Note: the JSX and esnext packages should both be marked as deprecated after the release_